### PR TITLE
OF-Config 1.1.1: allows empty <controllers/>

### DIFF
--- a/priv/of-config-1.1.1.xsd
+++ b/priv/of-config-1.1.1.xsd
@@ -959,7 +959,7 @@
                 </xs:annotation>
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element name="controller" maxOccurs="unbounded">
+                        <xs:element name="controller" minOccurs="0" maxOccurs="unbounded">
                             <xs:annotation>
                                 <xs:documentation> The list of OpenFlow Controllers that are
                                     assigned to the OpenFlow Logical Switch. The switch MUST NOT


### PR DESCRIPTION
at least the published version of OF-Config 1.1.1 specification
allows it.  (see p.112)
