### PR TITLE
Fix encoding/decoding of /capable-switch/resources/queue/port/ element

### DIFF
--- a/src/of_config_decoder.erl
+++ b/src/of_config_decoder.erl
@@ -115,7 +115,7 @@ transform_xml(#xmlElement{name = 'queue', content = C, attributes = Attrs}) ->
     #queue{operation = get_operation(Attrs),
            resource_id = get_from_child(string, 'resource-id', C),
            id = get_from_child(integer, 'id', C),
-           port = get_from_child(integer, 'port', C),
+           port = get_from_child(string, 'port', C),
            properties = transform_xml(get_child(properties, C))
           };
 transform_xml(#xmlElement{name = 'properties', content = C}) ->

--- a/src/of_config_encoder.erl
+++ b/src/of_config_encoder.erl
@@ -175,7 +175,7 @@ simple_form(#queue{resource_id = ResourceId,
     element('queue', list,
             [element('resource-id', string, ResourceId),
              element('id', integer, Id),
-             element('port', integer, Port),
+             element('port', string, Port),
              element('properties', nested, Properties)]);
 %% TODO: Add DSAKeyValue
 simple_form(#private_key_rsa{modulus = Modulus,

--- a/test/of_config_fixtures.erl
+++ b/test/of_config_fixtures.erl
@@ -73,7 +73,7 @@ get_config_11() ->
                                                                  supported = undefined,advertised_peer = undefined},
                                        tunnel = undefined},
                                  #queue{resource_id = "LogicalSwitch1-Port1Queue1",
-                                        port = 1, properties = #queue_properties{min_rate = 100}}],
+                                        port = "LogicalSwitch0-Port1", properties = #queue_properties{min_rate = 100}}],
                     logical_switches = [#logical_switch{id = "LogicalSwitch0",
                                                         capabilities = undefined,datapath_id = "AA:00:11:22:33:44:55:66",
                                                         enabled = true,check_controller_certificate = false,

--- a/test/xml/set-queue-1.1.1.xml
+++ b/test/xml/set-queue-1.1.1.xml
@@ -3,6 +3,7 @@
   <resources>
     <queue operation="replace">
       <resource-id>queue1</resource-id>
+      <port>port1</port>
       <properties>
         <min-rate>10</min-rate>
       </properties>

--- a/test/xml/set-queue-1.1.xml
+++ b/test/xml/set-queue-1.1.xml
@@ -3,6 +3,7 @@
   <resources>
     <queue operation="replace">
       <resource-id>queue1</resource-id>
+      <port>port1</port>
       <properties>
         <min-rate>10</min-rate>
       </properties>


### PR DESCRIPTION
This element has been represented by an integer but the specification
says that it should reference /capable-switch/resources/port/resource-id,
which is a string.

(Motivated by FlowForwarding/LINC-Switch#302).
